### PR TITLE
Massive refactor to move all 'Definition' specific code to a new file

### DIFF
--- a/src/definition.js
+++ b/src/definition.js
@@ -1,0 +1,128 @@
+/**
+ * Definition Module
+ *
+ * This file contains the code for finding the parent `Ext.define` or `Ext.override` definition for a `callParent` call.
+ */
+export default function initDefinitionFactory(t) {
+
+    function isCalleeExtDefine(callee) {
+        return t.isIdentifier(callee.property, {name: 'define'});
+    }
+
+    function isCalleeExtOverride(callee) {
+        return t.isIdentifier(callee.property, {name: 'override'});
+    }
+
+    function isDefinition(extNames) {
+        extNames = extNames || ['Ext'];
+        return function isDefinition(path) {
+            if (!path.isCallExpression()) {
+                return false;
+            }
+            let callee = path.node.callee;
+            return t.isMemberExpression(callee) &&
+                t.isIdentifier(callee.object) && extNames.includes(callee.object.name) &&
+                (isCalleeExtDefine(callee) || isCalleeExtOverride(callee));
+        };
+    }
+
+    function getProtoPropFromObjectExpression(objectExpression) {
+        return objectExpression.properties.find((prop) => {
+            return t.isIdentifier(prop.key) && (prop.key.name === 'extend' || prop.key.name === 'override');
+        });
+    }
+
+    const returnStatementVisitor = {
+        ReturnStatement(path, state) {
+            if (!path.findParent((p) => p.isFunctionExpression()) === state.functionExpression) {
+                return;
+            }
+            path.stop(); // we've found the return statement, stop traversal
+            let returnArg = path.get('argument');
+            if (!returnArg.isObjectExpression()) {
+                return;
+            }
+            state.returnArg = returnArg.node;
+        }
+    };
+
+    function getFunctionDefineReturnObjectExpression(functionExpression) {
+        let nestedVisitorState = { functionExpression, returnArg: null };
+        functionExpression.traverse(returnStatementVisitor, nestedVisitorState);
+        return nestedVisitorState.returnArg;
+    }
+
+    function getDefineProtoProp(bodyArg) {
+        if (bodyArg.isObjectExpression()) {
+            return getProtoPropFromObjectExpression(bodyArg.node);
+        } else if (bodyArg.isFunctionExpression()) {
+            let objectExpression = getFunctionDefineReturnObjectExpression(bodyArg);
+            if (!objectExpression) {
+                return;
+            }
+            return getProtoPropFromObjectExpression(objectExpression);
+        }
+    }
+
+    function buildMemberExpression(stringRef) {
+        return stringRef.split('.').reduce((last, next) => {
+            return last ? t.memberExpression(last, t.identifier(next)) : t.identifier(next);
+        }, null);
+    }
+
+    function getPrototypeRef(prototypeValue) {
+        return t.isStringLiteral(prototypeValue) ? buildMemberExpression(prototypeValue.value) : prototypeValue;
+    }
+
+    class AbstractDefinition {
+        constructor(path) {
+            this.path = path;
+        }
+
+        prependVariableRef(value) {
+            const refVar = this.path.scope.generateUidIdentifier('o');
+            this.path.insertBefore(t.variableDeclaration('var', [t.variableDeclarator(refVar,value)]));
+            return refVar;
+        }
+    }
+
+    class DefineDefinition extends AbstractDefinition {
+        constructor(path) {
+            super(path);
+
+            const bodyArg = path.get('arguments.1');
+            const protoProp = getDefineProtoProp(bodyArg);
+            this.protoRef = protoProp ? getPrototypeRef(protoProp.value) : buildMemberExpression('Ext.Base');
+
+            this.isOverride = protoProp && protoProp.key.name === 'override';
+        }
+    }
+
+    class OverrideDefinition extends AbstractDefinition {
+        constructor(path) {
+            super(path);
+
+            const prototypeValue = path.get('arguments.0').node;
+            this.protoRef = getPrototypeRef(prototypeValue);
+
+            this.isOverride = true;
+        }
+    }
+
+    /**
+     * Find the `Ext.define` or `Ext.override` definition
+     *
+     * If the `callParent` call is within an `Ext.define`, then a `DefineDefinition` is returned
+     * If the `callParent` call is within an `Ext.override`, then a `OverrideDefinition` is returned
+     *
+     * In either case, they expose `protoRef`, `isOverride` properties, and a `createPrependedVariableRef` method which
+     * is used for prepending the reference to the overriden method when the definition is overriding a class.
+     */
+    return function findParentDefinition(childPath, extNames) {
+        const path = childPath.findParent(isDefinition(extNames));
+        if (!path) {
+            throw childPath.buildCodeFrameError("Unable to find 'Ext.define' or 'Ext.override' for this 'callParent'");
+        }
+        return isCalleeExtOverride(path.node.callee) ? new OverrideDefinition(path) : new DefineDefinition(path);
+    }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,9 @@
 
+import initDefinitionFactory from './definition';
+
 export default function ({ types: t }) {
+
+    const findParentDefinition = initDefinitionFactory(t);
 
     function isThisOrMeExpression(node) {
         return t.isThisExpression(node) || t.isIdentifier(node, { name: 'me' });
@@ -11,106 +15,14 @@ export default function ({ types: t }) {
             t.isIdentifier(node.property, { name: 'callParent' });
     }
 
-    function isMethodCall(methodName, extNames) {
-        extNames = extNames || ['Ext'];
-        return function (path) {
-            if (!path.isCallExpression()) {
-                return false;
-            }
-            let callee = path.node.callee;
-            return t.isMemberExpression(callee) &&
-                t.isIdentifier(callee.object) && extNames.includes(callee.object.name) &&
-                t.isIdentifier(callee.property, { name: methodName });
-        };
-    }
-
-    function isExtDefineCall(extNames) {
-        return isMethodCall('define', extNames);
-    }
-
-    function isExtOverrideCall(extNames) {
-        return isMethodCall('override', extNames);
-    }
-
-    function getProtoPropFromObjectExpression(objectExpression) {
-        return objectExpression.properties.find((prop) => {
-            return t.isIdentifier(prop.key) && (prop.key.name === 'extend' || prop.key.name === 'override');
-        });
-    }
-
-    function getProtoPropStringLiteral(stringLiteral) {
-        return stringLiteral.node;
-    }
-
-    const returnStatementVisitor = {
-        ReturnStatement(path) {
-            if (!path.findParent((p) => p.isFunctionExpression()) === this.functionExpression) {
-                return;
-            }
-            path.stop(); // we've found the return statement, stop traversal
-            let returnArg = path.get('argument');
-            if (!returnArg.isObjectExpression()) {
-                return;
-            }
-            this.returnArg = returnArg.node;
-        }
-    };
-
-    function getFunctionDefineReturnObjectExpression(functionExpression) {
-        let nestedVisitorState = { functionExpression, returnArg: null };
-        functionExpression.traverse(returnStatementVisitor, nestedVisitorState);
-        return nestedVisitorState.returnArg;
-    }
-
-    function getProtoProp({ defineCall, overrideCall }) {
-        const bodyArg = defineCall ? defineCall.get('arguments.1') : overrideCall.get('arguments.0');
-        if (bodyArg.isObjectExpression()) {
-            return getProtoPropFromObjectExpression(bodyArg.node);
-        } else if (bodyArg.isFunctionExpression()) {
-            let objectExpression = getFunctionDefineReturnObjectExpression(bodyArg);
-            if (!objectExpression) {
-                return;
-            }
-            return getProtoPropFromObjectExpression(objectExpression);
-        } else if (bodyArg.isStringLiteral()) {
-            return getProtoPropStringLiteral(bodyArg);
-        }
-    }
-
-    function getDefineOverrideMethodRef(methodRef, defineCall) {
-        const methodRefVar = defineCall.scope.generateUidIdentifier('o');
-        defineCall.insertBefore(
-            t.variableDeclaration(
-                'var',
-                [
-                    t.variableDeclarator(
-                        methodRefVar,
-                        methodRef
-                    )
-                ]
-            )
-        );
-        return methodRefVar;
-    }
-
     function isClassMethod(path) {
         return (path.isObjectProperty() && t.isFunction(path.node.value)) ||
             path.isObjectMethod();
     }
 
-    function buildMemberExpression(stringRef) {
-        return stringRef.split('.').reduce((last, next) => {
-            return last ? t.memberExpression(last, t.identifier(next)) : t.identifier(next);
-        }, null);
-    }
-
     function buildMethodRef(protoRef, methodName) {
         return t.memberExpression(
-            t.logicalExpression(
-                '||',
-                t.memberExpression(protoRef, t.identifier('prototype')),
-                protoRef
-            ),
+            t.logicalExpression('||', t.memberExpression(protoRef, t.identifier('prototype')), protoRef),
             t.identifier(methodName)
         );
     }
@@ -121,15 +33,12 @@ export default function ({ types: t }) {
             t.callExpression(memberExpression, [t.thisExpression()]);
     }
 
-    function getProtoRef(protoProp) {
-        if (!protoProp) {
-            return buildMemberExpression('Ext.Base');
+    function getMethodName(callParentPath) {
+        const clsMethod = callParentPath.findParent(isClassMethod);
+        if (!clsMethod) {
+            throw path.buildCodeFrameError("Unable to find method declaration for this 'callParent'");
         }
-
-        if (t.isStringLiteral(protoProp))
-            return buildMemberExpression(protoProp.value);
-
-        return t.isStringLiteral(protoProp.value) ? buildMemberExpression(protoProp.value.value) : protoProp.value;
+        return clsMethod.node.key.name;
     }
 
     return {
@@ -138,29 +47,19 @@ export default function ({ types: t }) {
                 if (!isCallParentCallee(path.node.callee)) {
                     return;
                 }
-                const defineCall = path.findParent(isExtDefineCall(state.opts.extNames))
-                const overrideCall = path.findParent(isExtOverrideCall(state.opts.extNames));
-                if (!defineCall && !overrideCall) {
-                    throw path.buildCodeFrameError("Unable to find 'Ext.define' or 'Ext.override for this 'callParent'");
+
+                // The name of the method which the `callParent` is within
+                const methodName = getMethodName(path);
+
+                // The definition (either `Ext.define` or `Ext.override`)
+                const definition = findParentDefinition(path, state.opts.extNames);
+
+                let methodRef = buildMethodRef(definition.protoRef, methodName);
+                if (definition.isOverride) {
+                    methodRef = definition.prependVariableRef(methodRef);
                 }
 
-                const clsMethod = path.findParent(isClassMethod);
-                if (!clsMethod) {
-                    throw path.buildCodeFrameError("Unable to find method declaration for this 'callParent'");
-                }
-                const methodName = clsMethod.node.key.name;
-
-                const protoProp = getProtoProp({ defineCall, overrideCall });
-                const isDefineOverride = protoProp && protoProp.key && protoProp.key.name === 'override';
-                const protoRef = getProtoRef(protoProp);
-
-                let methodRef = buildMethodRef(protoRef, methodName);
-                if (overrideCall || isDefineOverride) {
-                    methodRef = getDefineOverrideMethodRef(methodRef, (defineCall || overrideCall));
-                }
-
-                const args = path.node.arguments;
-                path.replaceWith(buildReplacement(methodRef, args));
+                path.replaceWith(buildReplacement(methodRef, path.node.arguments));
             }
         }
     };


### PR DESCRIPTION
This moves all of the code for finding the `Ext.define` or `Ext.override` definition into a new file, and has some big refactoring of how this code is structured.

There is now a clear separation between the code paths for when we're in `Ext.define` and when we're in `Ext.override`, and each will return a `Definition` instance of either `DefineDefinition` or `OverrideDefinition` respectively.

This means that the codepath for `OverrideDefinition` can skip out a lot of the inspection for the prototype property, and determining whether it's an `extend` or `override` prototype (it knows it's always an override).

Both `Definition` classes extend a common abstract which handles the common requirement for prepending the method reference before the definition when it is an override.